### PR TITLE
Fixes competition rank bug

### DIFF
--- a/app/src/lib/TBAUtils.ts
+++ b/app/src/lib/TBAUtils.ts
@@ -83,7 +83,7 @@ export class TBA {
    * Returns the rank of the team at the competition
    * @param comp_id the competition id
    * @param team_number the team number
-   * @returns the rank of the team at the competition, or -1 if the competition has not taken place yet
+   * @returns the rank of the team at the competition, or -1 if the competition has not taken place yet, or -2 if the team is not ranked
    */
   static async getTeamRank(
     comp_id: string,
@@ -106,10 +106,16 @@ export class TBA {
       return -1;
     }
     const data = await response.json();
+    console.log('data response', data);
 
     // this means that the competition has not taken place yet
     if (data === null) {
       return -1;
+    }
+
+    // if the qualification ranking is null, then the team is not ranked
+    if (data.qual == null) {
+      return -2;
     }
 
     return data.qual.ranking.rank;

--- a/app/src/screens/search-flow/CompetitionRank.tsx
+++ b/app/src/screens/search-flow/CompetitionRank.tsx
@@ -116,7 +116,11 @@ function CompetitionRank({team_number}: {team_number: number}) {
               marginTop: '2%',
               fontWeight: '800',
             }}>
-            Ranked #{currentCompetitionRank}
+            {currentCompetitionRank === -1
+              ? 'Has not competed yet'
+              : currentCompetitionRank === -2
+              ? 'Unranked'
+              : 'Ranked #' + {currentCompetitionRank}}
           </Text>
           <Text
             style={{
@@ -216,8 +220,9 @@ function CompetitionRank({team_number}: {team_number: number}) {
                   }}>
                   {item.rank === -1
                     ? 'Future Competition'
+                    : item.rank === -2
+                    ? 'Unranked'
                     : 'Rank #' + item.rank}
-                  {/*Rank {item.rank}*/}
                 </Text>
               </View>
             );

--- a/app/src/screens/search-flow/SearchMain.tsx
+++ b/app/src/screens/search-flow/SearchMain.tsx
@@ -29,7 +29,7 @@ const SearchMain: React.FC<Props> = ({navigation}) => {
 
   // initial data fetch
   useEffect(() => {
-    TBA.getTeamsAtCompetition('2023cc').then(teams => {
+    TBA.getTeamsAtCompetition('2023mttd').then(teams => {
       // sort teams by team number
       teams.sort((a, b) => {
         return a.team_number - b.team_number;


### PR DESCRIPTION
The app used to not recognize unranked competitions, and this would throw an error and prevent the rankings from being shown. This also fixes the app showing 'Ranked -1' when the competition has yet to happen.