### PR TITLE
Search Screen fixes

### DIFF
--- a/app/src/screens/search-flow/CompetitionChanger.tsx
+++ b/app/src/screens/search-flow/CompetitionChanger.tsx
@@ -21,7 +21,6 @@ interface CompetitionChangerProps {
   loading: boolean;
 }
 
-let NO_COMPETITION_TITLE = 'Loading...';
 const CompetitionChanger = ({
   currentCompId,
   setCurrentCompId,
@@ -50,7 +49,7 @@ const CompetitionChanger = ({
     if (currentCompId === -1) {
       CompetitionsDB.getCurrentCompetition().then(competition => {
         if (competition != null) {
-          setCurrentCompId(-1);
+          setCurrentCompId(competition.id);
         } else {
           // TODO: handle when there is no current competition
           setCurrentCompId(-1);
@@ -156,7 +155,9 @@ const CompetitionChanger = ({
                   textAlign: 'center',
                   fontWeight: '700',
                 }}>
-                {compnameToIcon(competitionName)}
+                {competitionName === 'Loading...'
+                  ? ''
+                  : compnameToIcon(competitionName)}
               </Text>
             </View>
           );


### PR DESCRIPTION
* Sets the search screen to use the active competition, if there is one.
* Removes the "L" from the icon when a competition hasn't been selected